### PR TITLE
Add temporary black CSS-filter for OSM

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,7 @@ body {
     padding: 0;
     margin: 0;
     font-family: 'Iset Sans', sans-serif;
+    background: black;
 }
 
 a {
@@ -29,4 +30,13 @@ body {
         color: white;
         background: black;
     }
+}
+
+/* TODO Tile server with black Open Street Map */
+.leaflet-tile-pane {
+    filter: invert(1) sepia(1) saturate(.2) hue-rotate(270deg) brightness(.7) contrast(1.1);
+}
+
+.leaflet-container {
+    background: none !important;
 }


### PR DESCRIPTION
Add rule `filter: invert(1) sepia(0.75) saturate(2) hue-rotate(180deg) brightness(1.25) contrast(1.1)`

**Preview link**
https://ekbdev-map-feature-filter-map.vercel.app/

**Before**
![image](https://user-images.githubusercontent.com/22644149/201464749-e6a44f43-0bc2-4d33-8926-3f7fae95dda5.png)


**After**
![image](https://user-images.githubusercontent.com/22644149/201463144-2f3eb2a9-5561-40ef-b5d0-f8793eb3107c.png)
