### PR TITLE
Don't show `<Welcome>` after closing

### DIFF
--- a/components/UI/Filters/Filters.tsx
+++ b/components/UI/Filters/Filters.tsx
@@ -13,6 +13,7 @@ import { FILTERS_CONFIG } from './Filters.config';
 import { FilterConfigItem, FilterType } from './Filters.types';
 
 export function Filters() {
+    // TODO Add to Redux after development modal window with project information
     const [isWelcomeClosed, setIsWelcomeClosed] = useState(localStorage.getItem('is-welcome-closed') !== null);
 
     const onClose = useCallback(() => {

--- a/components/UI/Filters/Filters.tsx
+++ b/components/UI/Filters/Filters.tsx
@@ -13,10 +13,11 @@ import { FILTERS_CONFIG } from './Filters.config';
 import { FilterConfigItem, FilterType } from './Filters.types';
 
 export function Filters() {
-    const [isWelcomeClosed, setIsWelcomeClosed] = useState(false);
+    const [isWelcomeClosed, setIsWelcomeClosed] = useState(localStorage.getItem('is-welcome-closed') !== null);
 
     const onClose = useCallback(() => {
         setIsWelcomeClosed(true);
+        localStorage.setItem('is-welcome-closed', '');
     }, []);
 
     const dispatch = useDispatch();


### PR DESCRIPTION
We will hide the welcome message after closing to save space on the page. There is currently no way to return it.

This is a **temporary** solution without Redux. Until we have the design of the modal window with information.

![image](https://github.com/ekaterinburgdev/map/assets/22644149/24efa454-15a1-458b-b917-a485a88361ee)

