### PR TITLE
Add support responsive `width="auto"` in `<RangeHistogram>`

### DIFF
--- a/components/Model/RangeBaseFilter/RangeBaseFilter.tsx
+++ b/components/Model/RangeBaseFilter/RangeBaseFilter.tsx
@@ -63,7 +63,7 @@ export function RangeBaseFilter({
         <RangeHistogram
             data={rangeData}
             onChange={onChange}
-            width={368}
+            width="auto"
             height={128}
             defaultMin={defaultMin}
             defaultMax={defaultMax}

--- a/components/UI/Filters/components/Filter/Filter.module.css
+++ b/components/UI/Filters/components/Filter/Filter.module.css
@@ -1,6 +1,5 @@
 .filter {
     position: relative;
-    overflow-x: scroll;
     padding: 0 16px;
     opacity: 0;
     box-sizing: content-box;

--- a/components/UI/Filters/components/Filter/Filter.module.css
+++ b/components/UI/Filters/components/Filter/Filter.module.css
@@ -1,5 +1,6 @@
 .filter {
     position: relative;
+    overflow: auto;
     padding: 0 16px;
     opacity: 0;
     box-sizing: content-box;

--- a/components/UI/RangeHistogram/RangeHistogram.module.css
+++ b/components/UI/RangeHistogram/RangeHistogram.module.css
@@ -1,5 +1,10 @@
 .histogram {
-    padding: 16px 15px 0;
+    --histogram-padding: 10px;
+    position: relative;
+    padding-top: var(--histogram-padding);
+    padding-right: var(--histogram-padding);
+    padding-bottom: 0;
+    padding-left: var(--histogram-padding);
     box-sizing: content-box;
     user-select: none;
 }

--- a/components/UI/RangeHistogram/RangeHistogram.module.css
+++ b/components/UI/RangeHistogram/RangeHistogram.module.css
@@ -1,10 +1,19 @@
 .histogram {
-    --histogram-padding: 10px;
+    --histogram-color-active: white;
+    --histogram-color-disabled: #2c3a5e;
+
+    --histogram-thumb-color-active: white;
+    --histogram-thumb-color-disabled: #55647d;
+
+    --histogram-padding-x: 10px;
+}
+
+.histogram {
     position: relative;
-    padding-top: var(--histogram-padding);
-    padding-right: var(--histogram-padding);
+    padding-top: 32px;
+    padding-right: var(--histogram-padding-x);
     padding-bottom: 0;
-    padding-left: var(--histogram-padding);
+    padding-left: var(--histogram-padding-x);
     box-sizing: content-box;
     user-select: none;
 }

--- a/components/UI/RangeHistogram/RangeHistogram.tsx
+++ b/components/UI/RangeHistogram/RangeHistogram.tsx
@@ -9,7 +9,7 @@ import { HistogramData, MinMax, Range } from './types';
 interface Props {
     data?: HistogramData;
     onChange: (range: MinMax) => void;
-    width?: number;
+    width?: number | 'auto',
     height?: number;
     defaultMin: number;
     defaultMax: number;
@@ -17,7 +17,7 @@ interface Props {
 
 export function RangeHistogram({
     data,
-    width = 360,
+    width = 'auto',
     height = 100,
     onChange,
     defaultMin,
@@ -43,11 +43,15 @@ export function RangeHistogram({
 
     return data ? (
         <div className={histogramStyles.histogram} style={{ width }}>
-            <BarChart data={data} range={range} height={height} onSelect={onSelect} />
+            <BarChart
+                data={data}
+                range={range}
+                height={height}
+                onSelect={onSelect}
+            />
             <div className={histogramStyles.histogram__range}>
                 <Slider
                     data={data}
-                    width={width}
                     min={defaultMin}
                     max={defaultMax}
                     currentMin={sliderRange.min}

--- a/components/UI/RangeHistogram/components/Axis.module.css
+++ b/components/UI/RangeHistogram/components/Axis.module.css
@@ -5,7 +5,7 @@
     font-size: 14px;
     line-height: 18px;
     column-gap: 1px;
-    margin: 0 -20px;
+    margin: 0 calc(-1 * var(--histogram-padding));
     color: var(--histogram-color-active);
 }
 

--- a/components/UI/RangeHistogram/components/Axis.module.css
+++ b/components/UI/RangeHistogram/components/Axis.module.css
@@ -2,10 +2,10 @@
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
-    font-size: 14px;
+    font-size: 11px;
     line-height: 18px;
     column-gap: 1px;
-    margin: 0 calc(-1 * var(--histogram-padding));
+    margin: 0 calc(-1 * var(--histogram-padding-x));
     color: var(--histogram-color-active);
 }
 
@@ -26,4 +26,10 @@
 
 .axis__item:not(.axis__item_active):hover {
     color: var(--histogram-color-active);
+}
+
+@media screen and (min-width: 768px) {
+    .axis {
+        font-size: 14px;
+    }
 }

--- a/components/UI/RangeHistogram/components/Slider.module.css
+++ b/components/UI/RangeHistogram/components/Slider.module.css
@@ -1,6 +1,6 @@
 .slider {
     position: absolute;
-    width: calc(100% - var(--histogram-padding) * 2);
+    width: calc(100% - var(--histogram-padding-x) * 2);
 }
 
 .slider__track,
@@ -31,7 +31,7 @@
 .thumb {
     pointer-events: none;
     position: absolute;
-    width: calc(100% - var(--histogram-padding));
+    width: calc(100% - var(--histogram-padding-x));
     height: 0;
 }
 

--- a/components/UI/RangeHistogram/components/Slider.module.css
+++ b/components/UI/RangeHistogram/components/Slider.module.css
@@ -1,5 +1,6 @@
 .slider {
-    position: relative;
+    position: absolute;
+    width: calc(100% - var(--histogram-padding) * 2);
 }
 
 .slider__track,
@@ -30,6 +31,7 @@
 .thumb {
     pointer-events: none;
     position: absolute;
+    width: calc(100% - var(--histogram-padding));
     height: 0;
 }
 
@@ -57,6 +59,7 @@
     pointer-events: all;
     position: relative;
     transition: all 0.3s ease;
+    transform: translate(-50%, 0);
 }
 
 .thumb:hover::-webkit-slider-thumb {
@@ -78,4 +81,5 @@
     margin-bottom: 2px;
     pointer-events: all;
     position: relative;
+    transform: translate(-50%, 0);
 }

--- a/components/UI/RangeHistogram/components/Slider.tsx
+++ b/components/UI/RangeHistogram/components/Slider.tsx
@@ -9,7 +9,6 @@ import sliderStyles from './Slider.module.css';
 
 interface Props {
     data: HistogramData;
-    width: number;
     min: number;
     max: number;
     onChange: Function;
@@ -20,7 +19,6 @@ interface Props {
 const ERROR = 0.15;
 
 export function Slider({
-    width,
     min,
     max,
     currentMin = min,
@@ -89,15 +87,6 @@ export function Slider({
         setMaxValue(maxPercent);
     }, [currentMax, data]);
 
-    const thumbStyles = useMemo(
-        () => ({
-            width: width + 10,
-            marginRight: -5,
-            marginLeft: -5,
-        }),
-        [width],
-    );
-
     return (
         <div>
             <input
@@ -106,7 +95,6 @@ export function Slider({
                 max={100}
                 value={minValue}
                 ref={minValRef}
-                style={thumbStyles}
                 className={classnames(sliderStyles.thumb, sliderStyles.thumb_left, {
                     [sliderStyles.thumb_zindex_5]: minValue > max - 100,
                 })}
@@ -121,7 +109,6 @@ export function Slider({
                 max={100}
                 value={maxValue}
                 ref={maxValueRef}
-                style={thumbStyles}
                 className={classnames(sliderStyles.thumb, sliderStyles.thumb_right)}
                 onChange={(event: ChangeEvent<HTMLInputElement>) => {
                     const value = Math.max(+event.target.value, minValue + 1);
@@ -129,7 +116,7 @@ export function Slider({
                 }}
             />
 
-            <div className={sliderStyles.slider} style={{ width }}>
+            <div className={sliderStyles.slider}>
                 <div className={sliderStyles.slider__track} />
                 <div ref={range} className={sliderStyles.slider__range} />
             </div>

--- a/components/UI/RangeHistogram/components/Slider.tsx
+++ b/components/UI/RangeHistogram/components/Slider.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useState, useRef, useMemo } from 'react';
+import React, { ChangeEvent, useEffect, useState, useRef } from 'react';
 import classnames from 'classnames';
 
 import { HistogramData } from '../types';

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -1,8 +1,0 @@
-/* TODO: move histogram variables to separate file */
-:root {
-    --histogram-color-active: white;
-    --histogram-color-disabled: #2c3a5e;
-
-    --histogram-thumb-color-active: white;
-    --histogram-thumb-color-disabled: #55647d;
-}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,7 +2,6 @@
 @import './checkbox.css';
 @import './leaflet.css';
 @import './modal.css';
-@import './colors.css';
 
 * {
     box-sizing: border-box;


### PR DESCRIPTION
Now `RangeHistogram` is responsive

- [x] Added `width="auto"` prop value in `<RangeHistogram>`
- [x] Moved indents to a CSS variable `--histogram-padding`. Now this dependency should be clearer

https://github.com/ekaterinburgdev/map/assets/22644149/a761b4e7-4d28-4fa0-8e96-d26977ca4202


closes https://github.com/ekaterinburgdev/map/issues/44