### PR TITLE
Add `isVerified` notice

### DIFF
--- a/common/types/sources.ts
+++ b/common/types/sources.ts
@@ -1,0 +1,9 @@
+export interface SourcesType {
+    [key: string]: Source;
+}
+
+export interface Source {
+    name: string;
+    link: string;
+    data: string;
+}

--- a/components/UI/Copyright/Copyright.tsx
+++ b/components/UI/Copyright/Copyright.tsx
@@ -1,37 +1,15 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { activeFilterSelector } from 'state/features/selectors';
-import { SOURCES_BY_TYPE } from 'common/constants/sources';
 import { MapContext } from 'components/UI/Map/providers/MapProvider';
-import { FilterType } from '../Filters/Filters.types';
+import { FILTERS_CONFIG } from '../Filters/Filters.config';
 
 import styles from './Copyright.module.css';
-
-function getSource(activeFilter) {
-    switch (activeFilter) {
-        case FilterType.HouseAge:
-        case FilterType.HouseFloor:
-        case FilterType.HouseWearTear:
-            return SOURCES_BY_TYPE.howoldthishouse.link;
-
-        case FilterType.DTP:
-            return SOURCES_BY_TYPE.dtp.link;
-
-        case FilterType.DesignCode:
-            return SOURCES_BY_TYPE.ekaterinburgdesign.link;
-
-        case FilterType.OKN:
-            return SOURCES_BY_TYPE.okn.link;
-
-        default:
-            return null;
-    }
-}
 
 export function Copyright() {
     const { loading } = useContext(MapContext);
     const activeFilter = useSelector(activeFilterSelector);
-    const copyright = getSource(activeFilter);
+    const copyright = FILTERS_CONFIG[activeFilter]?.source;
 
     return (
         <div className={styles.copyright} hidden={loading}>
@@ -46,7 +24,7 @@ export function Copyright() {
                         target="_blank"
                         rel="noreferrer"
                     >
-                        {new URL(copyright).host}
+                        {new URL(copyright.link).host}
                     </a>
                 </>
             )}

--- a/components/UI/Filters/Filters.config.ts
+++ b/components/UI/Filters/Filters.config.ts
@@ -5,6 +5,7 @@ import { DesignCodeFilter } from 'components/Model/DesignCode/Filter/DesignCodeF
 import { OknFilter } from 'components/Model/OKN/Filter/Okn/OknFilter';
 import { LinesFilter } from 'components/Model/Lines/Filter/LinesFilter';
 import { DTPFilter } from 'components/Model/DTP/Filter/DTPFilter';
+import { SOURCES_BY_TYPE } from 'common/constants/sources';
 import { FilterConfig, FilterType } from './Filters.types';
 
 // @ts-ignore
@@ -12,29 +13,42 @@ export const FILTERS_CONFIG: FilterConfig = {
     [FilterType.HouseAge]: {
         title: 'Возраст домов',
         component: HouseAgeFilter,
+        source: SOURCES_BY_TYPE.howoldthishouse,
+        isVerified: false,
     },
     [FilterType.HouseFloor]: {
         title: 'Этажность домов',
         component: HouseFloorFilter,
+        source: SOURCES_BY_TYPE.howoldthishouse,
+        isVerified: false,
     },
     [FilterType.HouseWearTear]: {
         title: 'Степень износа домов',
         component: HouseWearTearFilter,
+        source: SOURCES_BY_TYPE.howoldthishouse,
+        isVerified: false,
     },
     [FilterType.OKN]: {
         title: 'Объекты культурного наследия',
         component: OknFilter,
+        source: SOURCES_BY_TYPE.okn,
+        isVerified: false,
     },
     [FilterType.DesignCode]: {
         title: '«Дизайн-код Екатеринбурга»',
         component: DesignCodeFilter,
+        source: SOURCES_BY_TYPE.ekaterinburgdesign,
+        isVerified: true,
     },
     [FilterType.DTP]: {
         title: 'ДТП',
         component: DTPFilter,
+        source: SOURCES_BY_TYPE.dtp,
+        isVerified: true,
     },
     [FilterType.Line]: {
         title: 'Туристические маршруты',
         component: LinesFilter,
+        isVerified: true,
     },
 };

--- a/components/UI/Filters/Filters.module.css
+++ b/components/UI/Filters/Filters.module.css
@@ -27,18 +27,21 @@
 }
 
 .filters__notice {
-    margin-top: -12px;
-    margin-right: -16px;
-    margin-bottom: 20px;
-    margin-left: -16px;
+    margin-top: 12px;
+    margin-bottom: -4px;
     padding: 12px 16px;
-    background: #767533;
-    color: #fffcd2;
+    background: #3a4155;
+    color: #9c9ea8;
     font-size: 14px;
+    border-radius: 4px;
 }
 
 .filters__notice a {
     text-decoration: underline;
+
+    &:hover {
+        color: white;
+    }
 }
 
 @media screen and (min-width: 1440px) {

--- a/components/UI/Filters/Filters.module.css
+++ b/components/UI/Filters/Filters.module.css
@@ -26,6 +26,21 @@
     border-bottom-left-radius: 8px;
 }
 
+.filters__notice {
+    margin-top: -12px;
+    margin-right: -16px;
+    margin-bottom: 20px;
+    margin-left: -16px;
+    padding: 12px 16px;
+    background: #767533;
+    color: #fffcd2;
+    font-size: 14px;
+}
+
+.filters__notice a {
+    text-decoration: underline;
+}
+
 @media screen and (min-width: 1440px) {
     .filters__body {
         font-size: 16px;

--- a/components/UI/Filters/Filters.tsx
+++ b/components/UI/Filters/Filters.tsx
@@ -23,9 +23,11 @@ export function Filters() {
     return (
         <div className={styles.filters__body}>
             {(Object.entries(FILTERS_CONFIG) as [FilterType, FilterConfigItem][]).map(
-                ([type, { component: Component, title }], idx) => {
+                ([type, { component: Component, title, source, isVerified }], idx) => {
                     const id = `id:${type}-${idx}`;
                     const isActive = type === activeFilter;
+
+                    const sourceHost = source && new URL(source.link).host;
 
                     return (
                         <div key={id} className={styles.filters__item}>
@@ -37,6 +39,7 @@ export function Filters() {
                                 label={title}
                             />
                             <Filter isActive={isActive}>
+                                {!isVerified && <div className={styles.filters__notice}>Данные {source && <a href={source.link} target="_blank" rel="noreferrer">{sourceHost}</a>} содержат неточности. <a href="https://tally.so#tally-open=wLzxEG&tally-width=650&tally-overlay=1&tally-emoji-animation=none">Оставьте фидбек</a> — помогите улучшить карту</div>}
                                 {isActive && <Component />}
                             </Filter>
                         </div>

--- a/components/UI/Filters/Filters.tsx
+++ b/components/UI/Filters/Filters.tsx
@@ -23,11 +23,9 @@ export function Filters() {
     return (
         <div className={styles.filters__body}>
             {(Object.entries(FILTERS_CONFIG) as [FilterType, FilterConfigItem][]).map(
-                ([type, { component: Component, title, source, isVerified }], idx) => {
+                ([type, { component: Component, title, isVerified }], idx) => {
                     const id = `id:${type}-${idx}`;
                     const isActive = type === activeFilter;
-
-                    const sourceHost = source && new URL(source.link).host;
 
                     return (
                         <div key={id} className={styles.filters__item}>
@@ -39,8 +37,8 @@ export function Filters() {
                                 label={title}
                             />
                             <Filter isActive={isActive}>
-                                {!isVerified && <div className={styles.filters__notice}>Данные {source && <a href={source.link} target="_blank" rel="noreferrer">{sourceHost}</a>} содержат неточности. <a href="https://tally.so#tally-open=wLzxEG&tally-width=650&tally-overlay=1&tally-emoji-animation=none">Оставьте фидбек</a> — помогите улучшить карту</div>}
                                 {isActive && <Component />}
+                                {!isVerified && <div className={styles.filters__notice}>Данные берутся из&nbsp;публичных источников и&nbsp;содержат неточности. <a href="https://tally.so#tally-open=wLzxEG&tally-width=650&tally-overlay=1&tally-emoji-animation=none">Оставьте&nbsp;фидбек</a>&nbsp;— помогите улучшить карту</div>}
                             </Filter>
                         </div>
                     );

--- a/components/UI/Filters/Filters.types.ts
+++ b/components/UI/Filters/Filters.types.ts
@@ -1,4 +1,5 @@
 import { FunctionComponent } from 'react';
+import { Source } from 'common/types/sources';
 
 export enum FilterType {
     HouseAge = 'houseAge',
@@ -13,6 +14,8 @@ export enum FilterType {
 export interface FilterConfigItem {
     title: string;
     component: FunctionComponent;
+    source?: Source;
+    isVerified: boolean;
 }
 
 export type FilterConfig = Record<FilterType, FilterConfigItem>;


### PR DESCRIPTION
We have encountered comments about the incorrect data in the sources from [urbanists](https://t.me/ekb300svx/2942)

- [x] ~Yellow~ Gray notice with source & Tally form
- [x] `isVerified` option
- [x] Refactor. Move `FilterType` to sources list


<img width="458" alt="image" src="https://github.com/ekaterinburgdev/map/assets/22644149/1f5588e1-8599-4f97-8a9b-d8f1f41229fe">


_Old_
https://github.com/ekaterinburgdev/map/assets/22644149/6f145756-0a62-4057-8511-790b035ee907

