### PR TITLE
Fix tablet screen responsive + fully mobile-first

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -9,7 +9,7 @@ import { LeftSidebar } from 'components/UI/LeftSidebar/LeftSidebar';
 import { MobileFilters } from 'components/UI/Filters';
 import { RightSidebar } from 'components/UI/RightSidebar/RightSidebar';
 import { MobileCard } from 'components/UI/Card';
-import { useIsMobile } from 'helpers/isMobile';
+import { useIsDesktop } from 'helpers/isDesktop';
 import { MobileAboutProject } from 'components/UI/AboutProjectModal/MobileAboutProject';
 import { AboutProjectProvider } from 'state/providers/AboutProjectProvider';
 import { AboutProjectModal } from 'components/UI/AboutProjectModal/AboutProjectModal';
@@ -19,7 +19,7 @@ import { Copyright } from './UI/Copyright/Copyright';
 import { Map } from './Map/Map';
 
 export default function App() {
-    const isMobile = useIsMobile();
+    const isDesktop = useIsDesktop();
 
     return (
         <Provider store={store}>
@@ -27,7 +27,7 @@ export default function App() {
                 <AboutProjectProvider>
                     <MapContextProvider>
                         <Map />
-                        {!isMobile ? (
+                        {isDesktop ? (
                             <>
                                 <LeftSidebar />
                                 <RightSidebar />

--- a/components/UI/AboutProjectIcons/AboutProjectIcons.module.css
+++ b/components/UI/AboutProjectIcons/AboutProjectIcons.module.css
@@ -22,7 +22,7 @@
     filter: contrast(0.7);
 }
 
-@media screen and (min-width: 1150px) {
+@media screen and (min-width: 1024px) {
     .aboutProjectIcons {
         top: auto;
         right: 8px;

--- a/components/UI/Footer/Footer.module.css
+++ b/components/UI/Footer/Footer.module.css
@@ -1,19 +1,35 @@
-@media screen and (max-width: 1150px) {
+.footer [style*="--projects-panel"] {
+    top: -6px;
+    right: auto;
+    bottom: auto;
+    left: 8px;
+    transform-origin: left bottom;
+}
+
+.footer [class*="modal__content"] {
+    top: 72px;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    transform-origin: 20px 10px;
+}
+
+@media screen and (min-width: 600px) {
     .footer [style*="--projects-panel"] {
         top: 8px;
-        bottom: auto !important;
-        left: 8px;
-    }
-    
-    .footer [class*="modal__content"] {
-        top: 72px;
-        bottom: auto;
-        transform-origin: 20px 10px;
     }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (min-width: 1024px) {
     .footer [style*="--projects-panel"] {
-        top: -6px;
+        top: auto;
+        bottom: 8px;
+        left: 8px;
+    }
+
+    .footer [class*="modal__content"] {
+        top: auto;
+        bottom: 0;
+        transform-origin: 20px calc(100% - 10px);
     }
 }

--- a/components/UI/Footer/Footer.tsx
+++ b/components/UI/Footer/Footer.tsx
@@ -9,7 +9,6 @@ export function Footer() {
                 projects={[PROJECT_MAP, ...PRODUCTION_PROJECTS]}
                 activeProjectId={PROJECT_MAP.id}
                 theme={Theme.DARK}
-                style={{ left: '8px', bottom: '8px' }}
             />
         </div>
     );

--- a/components/UI/LeftSidebar/LeftSidebar.module.css
+++ b/components/UI/LeftSidebar/LeftSidebar.module.css
@@ -1,5 +1,6 @@
 .leftSidebar {
     width: 29%;
+    min-width: 340px;
     max-width: 435px;
     position: fixed;
     top: 8px;

--- a/helpers/isDesktop.ts
+++ b/helpers/isDesktop.ts
@@ -1,0 +1,5 @@
+import { useMatchMedia } from './use-match-media';
+
+const DESKTOP_WIDTH_MIN = 1024;
+
+export const useIsDesktop = () => useMatchMedia(`(min-width: ${DESKTOP_WIDTH_MIN}px)`);

--- a/helpers/isMobile.ts
+++ b/helpers/isMobile.ts
@@ -1,5 +1,0 @@
-import { useMatchMedia } from './use-match-media';
-
-export const MAX_MOBILE_WIDTH = 1024;
-
-export const useIsMobile = () => useMatchMedia(`(max-width: ${MAX_MOBILE_WIDTH}px)`);


### PR DESCRIPTION
In [this commit](https://github.com/ekaterinburgdev/map/commit/f85cc2fb55ed45ffaee13c377eb415bb6a2cf736#diff-ec4741143d1e917f1ec4869a6a7ab07e6920ac32a8cb014dd30d102ede8d5675) we accidentally broke tablet screen when change breakpoint 1150px → 1024px.

- [x] Updated values in all places
- [x] Added min-width to sidebar
- [x] Used mobile-first for fixed pannels (as in all places)

## Before
![image](https://github.com/ekaterinburgdev/map/assets/22644149/cdf67126-c714-4235-939a-4eba586fddc9)

## After
![image](https://github.com/ekaterinburgdev/map/assets/22644149/b9617cfb-a630-43cc-b951-0015729e3a25)
